### PR TITLE
Add Makefile and Boot Image Format template

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,52 @@
+# subdirectories of kr260 and kv260 under source directory - one per app
+APPS := $(wildcard kr260/*/ kv260/*/)
+
+# *.bit, *.dtsi and shell.json files under these specific directories
+BITS := $(wildcard $(patsubst %,%*.bit,$(APPS)))
+DTSIS := $(wildcard $(patsubst %,%*.dtsi,$(APPS)))
+JSONS := $(wildcard $(patsubst %,%shell.json,$(APPS)))
+
+# *.dtbo files to generate
+DTBOS := $(patsubst %.dtsi,%.dtbo,$(DTSIS))
+
+%.dtbo: %.dtsi
+	dtc -I dts -O dtb -o $@ $<
+
+# *.bif template
+BIF_TEMPLATE := template.bif
+
+# *.bif and *.bins files to generate
+BIFS := $(patsubst %.bit,%.bif,$(BITS))
+BINS := $(patsubst %.bit,%.bin,$(BITS))
+
+%.bif: %.bit
+	sed 's#@BIT@#$<#' <$(BIF_TEMPLATE) >$@
+
+%.bin: %.bif
+	bootgen -image $< -arch zynqmp -o $@ -w
+
+default: all
+
+all: bins dtbos
+bins: $(BINS)
+dtbos: $(DTBOS)
+
+clean:
+	rm -f $(BIFS)
+	rm -f $(BINS)
+	rm -f $(DTBOS)
+
+INSTALLDIR := $(DESTDIR)/lib/firmware/xilinx
+
+install: $(BINS) $(DTBOS) $(JSONS)
+	for f in $^; do \
+	    file=$$(basename $$f); \
+	    app=$$(basename $$(dirname $$f)); \
+	    board=$$(basename $$(dirname $$(dirname $$f))); \
+	    install -D -m 644 \
+	        $$f $(INSTALLDIR)/xilinx-app-$$board-$$app/$$file; \
+	done
+
+
+.PHONY: default all bins dtbos clean install
+

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 # subdirectories of kr260 and kv260 under source directory - one per app
 APPS := $(wildcard kr260/*/ kv260/*/)
 
-# *.bit, *.dtsi and shell.json files under these specific directories
+# *.bit, *.dtsi, *.xclbin and shell.json files under these specific directories
 BITS := $(wildcard $(patsubst %,%*.bit,$(APPS)))
 DTSIS := $(wildcard $(patsubst %,%*.dtsi,$(APPS)))
+XCLBINS := $(wildcard $(patsubst %,%*.xclbin,$(APPS)))
 JSONS := $(wildcard $(patsubst %,%shell.json,$(APPS)))
 
 # *.dtbo files to generate
@@ -38,7 +39,7 @@ clean:
 
 INSTALLDIR := $(DESTDIR)/lib/firmware/xilinx
 
-install: $(BINS) $(DTBOS) $(JSONS)
+install: $(BINS) $(DTBOS) $(XCLBINS) $(JSONS)
 	for f in $^; do \
 	    file=$$(basename $$f); \
 	    app=$$(basename $$(dirname $$f)); \

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ install: $(BINS) $(DTBOS) $(XCLBINS) $(JSONS)
 	    app=$$(basename $$(dirname $$f)); \
 	    board=$$(basename $$(dirname $$(dirname $$f))); \
 	    install -D -m 644 \
-	        $$f $(INSTALLDIR)/xilinx-app-$$board-$$app/$$file; \
+	        $$f $(INSTALLDIR)/$$board-$$app/$$file; \
 	done
 
 

--- a/template.bif
+++ b/template.bif
@@ -1,0 +1,4 @@
+all:
+{
+	[destination_device = pl] @BIT@
+}


### PR DESCRIPTION
Hi,

This allows building and installing all necessary files; note that I picked a /lib/firmware/xilinx/xilinx-app-$board-$name hierarchy.

Best,
LM